### PR TITLE
#2 Adding ability to view images in a slideshow-style viewer

### DIFF
--- a/Html/images.htm
+++ b/Html/images.htm
@@ -35,6 +35,7 @@
 			<p><a href="#" class="downloadImages">Download Images</a></p>
 			<p><a href="#" class="toggleBrokenLinks" title="Toggle gallery to show/hide images that have did not load"><span class="showHide">Show</span> broken images</a></p>
 			<p><a href="#" class="resizeImages" title="Resize images">Resize images to fit on page</a></p>
+			<p><a href="#" class="showViewer" title="Show viewer">Show images in viewer</a></p>
 			<p class="fuskUrl">&nbsp;</p>
 		</div>
 	</script>
@@ -42,6 +43,12 @@
 <body>
 	<div id="all">
 		<div id="content">&nbsp;</div>
+		<div id="viewer">
+			<div class="viewerItem modal"></div>
+			<div class="viewerItem small"><a class="previousImage"></a></div>
+			<div class="viewerItem current"><a></a></div>
+			<div class="viewerItem small"><a class="nextImage"></a></div>
+		</div>
 	</div>
 	<script type="text/javascript" src="/Scripts/images.js"></script>
 

--- a/Styles/styles.css
+++ b/Styles/styles.css
@@ -70,3 +70,41 @@ div#download-form {text-align:left;}
 	div#download-form { width: 350px; margin: 20px 0; }
     div#download-form table { margin: 1em 0; border-collapse: collapse; width: 100%; }
     div#download-form table td, div#download-form table th { border: 1px solid #eee; padding: .6em 10px; text-align: left; }
+
+.viewerItem
+{
+	top: 0;
+	bottom: 0;
+	right: 0;
+	left: 0;
+	position: fixed;
+	z-index: 100;
+}
+
+.viewerItem a
+{
+	display:block;
+	width:100%;
+	height:100%;
+	background-repeat: no-repeat;
+	background-size: contain;
+}
+
+.viewerItem.small
+{  
+	top: 10%;
+	bottom: 10%;
+	z-index: 99;
+	opacity: 0.2;
+}
+
+.viewerItem.modal
+{
+	background-color: #000;
+	z-index:98;
+}
+
+#viewer { display:none; }
+.viewerItem.current a { background-position: 50% 50%;}
+.viewerItem a.previousImage { background-position: 35% 50%; }
+.viewerItem a.nextImage { background-position: 65% 50%; }	}


### PR DESCRIPTION
Fixing issue #2 (Enable option to show one image at a time).

I've done this in a slideshow type style.

* Press Esc to toggle viewer (or click link)
* Left / Right arrow keys to navigate
* Main page kept in sync with what's on the viewer
* Nice little by-product is that fusks can now be navigated by keyboard too.