### PR TITLE
#14 Fixing issue with options page not loading. 

### DIFF
--- a/Html/options.htm
+++ b/Html/options.htm
@@ -78,8 +78,8 @@
 												<li>
 													<b>2.7 -</b>
 													<ul>
-														<li>Reduced the permissions level greatly. Previously, Fuskr required that you give us access to all websites and all browsing activity, but we only care about your current tab. Google Chrome now has that ability, so we've reduced the permissions needed accordingly!</li>
-														<li>Fixed an annoying bug where Fuskr wouldn't work on some links that didn't have numbers, and wouldn't revert to the image url.</li>
+														<li>Reduced the permissions level greatly. Previously, Fuskr required that you give us access to all websites and all browsing activity, but we only care about your current tab. Google Chrome now has that ability, so we’ve reduced the permissions needed accordingly!</li>
+														<li>Fixed an annoying bug where Fuskr wouldn’t work on some links that didn’t have numbers, and wouldn’t revert to the image url.</li>
 													</ul>
 												</li>
 												<li>


### PR DESCRIPTION
Changed apostrophes to quote markings since this seems to throw a wobbly with the templating.

Looks like this was probably broken since the text was added for v2.7 in the version history (Oops)