### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
  pull_request:
   branches: [master, main]
 
+permissions:
+ contents: read
+
 env:
  # Opt into Node.js 26 for all actions to avoid the Node.js 20 deprecation
  # warning emitted by transitively-used actions (e.g. actions/github-script).


### PR DESCRIPTION
Potential fix for [https://github.com/DanAtkinson/Fuskr/security/code-scanning/7](https://github.com/DanAtkinson/Fuskr/security/code-scanning/7)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege defaults. The best minimal, non-breaking fix is:

- `permissions:`
  - `contents: read`

Place it at workflow root (after `on:` block is a common location), so every job gets restricted token access unless a job later needs an override. This does not change existing build/test behavior while satisfying CodeQL and documenting intent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
