### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
  pull_request:
   branches: [master, main]
 
+permissions:
+ contents: read
+
 env:
  # Opt into Node.js 26 for all actions to avoid the Node.js 20 deprecation
  # warning emitted by transitively-used actions (e.g. actions/github-script).


### PR DESCRIPTION
Potential fix for [https://github.com/DanAtkinson/Fuskr/security/code-scanning/6](https://github.com/DanAtkinson/Fuskr/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit restricted token scopes by default.

Best single fix without changing functionality:
- In `.github/workflows/ci.yml`, insert after the `on:` trigger section (before `env:`) a workflow-level permissions block:
  - `contents: read`

Why this location/approach:
- Workflow-level permissions apply to all jobs unless overridden, which is simpler and consistent.
- `contents: read` is the minimal baseline recommended by GitHub/CodeQL and supports `actions/checkout`.
- No imports/dependencies/methods are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
