### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
  pull_request:
   branches: [master, main]
 
+permissions:
+ contents: read
+
 env:
  # Opt into Node.js 26 for all actions to avoid the Node.js 20 deprecation
  # warning emitted by transitively-used actions (e.g. actions/github-script).


### PR DESCRIPTION
Potential fix for [https://github.com/DanAtkinson/Fuskr/security/code-scanning/5](https://github.com/DanAtkinson/Fuskr/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs get least-privilege token access by default.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` block, before `env:` is clean and conventional):
  - `permissions:`
  - `contents: read`

Why this works:
- `actions/checkout` needs `contents: read`.
- Build/test/lint/package/artifact upload steps do not need write access to repository contents.
- This addresses the CodeQL complaint for all jobs at once, including `build-extensions`.

No new imports/methods/definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
