### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
  pull_request:
   branches: [master, main]
 
+permissions:
+ contents: read
+
 env:
  # Opt into Node.js 26 for all actions to avoid the Node.js 20 deprecation
  # warning emitted by transitively-used actions (e.g. actions/github-script).


### PR DESCRIPTION
Potential fix for [https://github.com/DanAtkinson/Fuskr/security/code-scanning/4](https://github.com/DanAtkinson/Fuskr/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs default to least privilege.  
Best minimal fix (without changing workflow behavior): set:

- `contents: read`

This is sufficient for checkout/read operations and documents the intended token scope. If a specific job later requires elevated permissions, it can override with a job-level `permissions` block.

Change location: near the top of `.github/workflows/ci.yml`, after `on:` (or before `env:`), at workflow root indentation.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
