### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-chrome.yml
+++ b/.github/workflows/deploy-chrome.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   deploy-chrome:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DanAtkinson/Fuskr/security/code-scanning/3](https://github.com/DanAtkinson/Fuskr/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (applies to all jobs unless overridden).  
For this workflow, the minimal required scopes appear to be:

- `contents: write` (required for `softprops/action-gh-release` to create a release and upload assets)

No other write scopes are clearly required by shown steps. Keeping permissions minimal preserves current behavior while reducing token overreach.

**File to edit:** `.github/workflows/deploy-chrome.yml`  
**Change location:** after the `on:` trigger block and before `jobs:`.  
No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
